### PR TITLE
Fix APT repository instructions to work

### DIFF
--- a/site/theme/index.html
+++ b/site/theme/index.html
@@ -30,7 +30,7 @@
       aria-labelledby="{{ version }}-tab">
       <pre><code class="language-bash">
 $ wget -O- {{ SITEURL }}/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-$ echo "deb [arch=$(dpkg --print-architecture), signed-by=/etc/apt/keyrings/envoy-keyring.gpg] {{ SITEURL }} {{ version }} main" | sudo tee /etc/apt/sources.list.d/envoy.list
+$ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] {{ SITEURL }} {{ version }} main" | sudo tee /etc/apt/sources.list.d/envoy.list
 $ sudo apt-get update
 $ sudo apt-get install envoy
 $ envoy --version

--- a/site/theme/index.html
+++ b/site/theme/index.html
@@ -29,8 +29,8 @@
       role="tabpanel"
       aria-labelledby="{{ version }}-tab">
       <pre><code class="language-bash">
-$ wget {{ SITEURL }}/signing.key  | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-$ echo "deb[signed-by=/etc/apt/keyrings/envoy-keyring.gpg] {{ SITEURL }} {{ version }} main" | sudo tee /etc/apt/sources.list.d/envoy.list
+$ wget -O- {{ SITEURL }}/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
+$ echo "deb [arch=$(dpkg --print-architecture), signed-by=/etc/apt/keyrings/envoy-keyring.gpg] {{ SITEURL }} {{ version }} main" | sudo tee /etc/apt/sources.list.d/envoy.list
 $ sudo apt-get update
 $ sudo apt-get install envoy
 $ envoy --version


### PR DESCRIPTION
The instructions on https://www.envoyproxy.io/docs/envoy/v1.32.1/start/install#install-envoy-on-debian-based-linux are correct, but the instructions here did not work out of the box.